### PR TITLE
setting NCCL_SHM_DISABLE=1 to allow multi-gpu use cases

### DIFF
--- a/4_ray_tune.ipynb
+++ b/4_ray_tune.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "a0cc082d-5ee6-45d1-8990-b646411a763a",
    "metadata": {
     "tags": []
@@ -38,6 +38,16 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "9135d364-57df-4523-ac43-79b56588fa0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"NCCL_SHM_DISABLE\"] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "a907d335-eeed-4f81-82fc-65cc47649dc4",
    "metadata": {
     "tags": []
@@ -62,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a094e6b1-5e6c-442a-ae27-5f1840ddb28e",
    "metadata": {
     "tags": []
@@ -91,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "e57b70bf-9040-4169-8157-a3d9c3f56069",
    "metadata": {
     "tags": []
@@ -197,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "29e6321a-c207-4145-bfc2-04b2905e58d0",
    "metadata": {
     "tags": []
@@ -235,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "b543f46f-a96b-48f5-94e8-b1203fdd41a6",
    "metadata": {
     "tags": []
@@ -245,21 +255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz to /home/cdsw/data/cifar-10-python.tar.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100.0%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting /home/cdsw/data/cifar-10-python.tar.gz to /home/cdsw/data\n",
+      "Files already downloaded and verified\n",
       "Files already downloaded and verified\n"
      ]
     },
@@ -267,12 +263,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-02-09 21:23:49,251\tWARNING services.py:1832 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 67108864 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=0.83gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.\n",
-      "2024-02-09 21:23:49,438\tINFO worker.py:1612 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
-      "2024-02-09 21:23:51,589\tINFO tune.py:226 -- Initializing Ray automatically. For cluster usage or custom Ray initialization, call `ray.init(...)` before `tune.run(...)`.\n",
-      "2024-02-09 21:23:51,594\tINFO tune.py:657 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n",
-      "2024-02-09 21:23:51,616\tINFO tensorboardx.py:178 -- pip install \"ray[tune]\" to see TensorBoard files.\n",
-      "2024-02-09 21:23:51,617\tWARNING callback.py:144 -- The TensorboardX logger cannot be instantiated because either TensorboardX or one of it's dependencies is not installed. Please make sure you have the latest version of TensorboardX installed: `pip install -U tensorboardx`\n"
+      "2024-06-16 20:12:38,192\tWARNING services.py:1832 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 67108864 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=4.52gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.\n",
+      "2024-06-16 20:12:38,401\tINFO worker.py:1621 -- Started a local Ray instance.\n",
+      "2024-06-16 20:12:41,424\tINFO tune.py:226 -- Initializing Ray automatically. For cluster usage or custom Ray initialization, call `ray.init(...)` before `tune.run(...)`.\n",
+      "2024-06-16 20:12:41,430\tINFO tune.py:657 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n",
+      "2024-06-16 20:12:41,466\tINFO tensorboardx.py:178 -- pip install \"ray[tune]\" to see TensorBoard files.\n",
+      "2024-06-16 20:12:41,466\tWARNING callback.py:144 -- The TensorboardX logger cannot be instantiated because either TensorboardX or one of it's dependencies is not installed. Please make sure you have the latest version of TensorboardX installed: `pip install -U tensorboardx`\n"
      ]
     },
     {
@@ -284,16 +280,16 @@
        "      <h3>Tune Status</h3>\n",
        "      <table>\n",
        "<tbody>\n",
-       "<tr><td>Current time:</td><td>2024-02-09 21:25:57</td></tr>\n",
-       "<tr><td>Running for: </td><td>00:02:05.89        </td></tr>\n",
-       "<tr><td>Memory:      </td><td>3.5/30.6 GiB       </td></tr>\n",
+       "<tr><td>Current time:</td><td>2024-06-16 20:19:59</td></tr>\n",
+       "<tr><td>Running for: </td><td>00:07:18.16        </td></tr>\n",
+       "<tr><td>Memory:      </td><td>9.0/186.6 GiB      </td></tr>\n",
        "</tbody>\n",
        "</table>\n",
        "    </div>\n",
        "    <div class=\"vDivider\"></div>\n",
        "    <div class=\"systemInfo\">\n",
        "      <h3>System Info</h3>\n",
-       "      Using AsyncHyperBand: num_stopped=3<br>Bracket: Iter 2.000: -1.4192476354837418 | Iter 1.000: -2.3028910999298096<br>Logical resource usage: 8.0/8 CPUs, 0/0 GPUs\n",
+       "      Using AsyncHyperBand: num_stopped=3<br>Bracket: Iter 2.000: -1.5778467945098877 | Iter 1.000: -1.688538500881195<br>Logical resource usage: 8.0/48 CPUs, 2.0/2 GPUs\n",
        "    </div>\n",
        "    \n",
        "  </div>\n",
@@ -302,12 +298,12 @@
        "    <h3>Trial Status</h3>\n",
        "    <table>\n",
        "<thead>\n",
-       "<tr><th>Trial name             </th><th>status    </th><th>loc              </th><th style=\"text-align: right;\">  batch_size</th><th style=\"text-align: right;\">  l1</th><th style=\"text-align: right;\">  l2</th><th style=\"text-align: right;\">        lr</th><th style=\"text-align: right;\">  iter</th><th style=\"text-align: right;\">  total time (s)</th><th style=\"text-align: right;\">   loss</th><th style=\"text-align: right;\">  accuracy</th></tr>\n",
+       "<tr><th>Trial name             </th><th>status    </th><th>loc               </th><th style=\"text-align: right;\">  batch_size</th><th style=\"text-align: right;\">  l1</th><th style=\"text-align: right;\">  l2</th><th style=\"text-align: right;\">        lr</th><th style=\"text-align: right;\">  iter</th><th style=\"text-align: right;\">  total time (s)</th><th style=\"text-align: right;\">   loss</th><th style=\"text-align: right;\">  accuracy</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>train_cifar_85549_00000</td><td>TERMINATED</td><td>100.100.40.88:613</td><td style=\"text-align: right;\">           8</td><td style=\"text-align: right;\"> 128</td><td style=\"text-align: right;\">   4</td><td style=\"text-align: right;\">0.00234423</td><td style=\"text-align: right;\">     3</td><td style=\"text-align: right;\">         72.9715</td><td style=\"text-align: right;\">1.33847</td><td style=\"text-align: right;\">    0.5236</td></tr>\n",
-       "<tr><td>train_cifar_85549_00001</td><td>TERMINATED</td><td>100.100.40.88:613</td><td style=\"text-align: right;\">          16</td><td style=\"text-align: right;\">   8</td><td style=\"text-align: right;\">   2</td><td style=\"text-align: right;\">0.00418661</td><td style=\"text-align: right;\">     1</td><td style=\"text-align: right;\">         17.1329</td><td style=\"text-align: right;\">2.30289</td><td style=\"text-align: right;\">    0.1012</td></tr>\n",
-       "<tr><td>train_cifar_85549_00002</td><td>TERMINATED</td><td>100.100.40.88:613</td><td style=\"text-align: right;\">           8</td><td style=\"text-align: right;\">  32</td><td style=\"text-align: right;\"> 256</td><td style=\"text-align: right;\">0.0884937 </td><td style=\"text-align: right;\">     1</td><td style=\"text-align: right;\">         26.489 </td><td style=\"text-align: right;\">2.31742</td><td style=\"text-align: right;\">    0.0991</td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00000</td><td>TERMINATED</td><td>100.100.8.10:2044 </td><td style=\"text-align: right;\">          16</td><td style=\"text-align: right;\"> 128</td><td style=\"text-align: right;\">   4</td><td style=\"text-align: right;\">0.012325  </td><td style=\"text-align: right;\">     3</td><td style=\"text-align: right;\">         72.2938</td><td style=\"text-align: right;\">1.60259</td><td style=\"text-align: right;\">    0.4051</td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00001</td><td>TERMINATED</td><td>100.100.8.10:24115</td><td style=\"text-align: right;\">           4</td><td style=\"text-align: right;\">   4</td><td style=\"text-align: right;\"> 256</td><td style=\"text-align: right;\">0.00120253</td><td style=\"text-align: right;\">     2</td><td style=\"text-align: right;\">        188.377 </td><td style=\"text-align: right;\">1.60811</td><td style=\"text-align: right;\">    0.4041</td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00002</td><td>TERMINATED</td><td>100.100.8.10:77348</td><td style=\"text-align: right;\">           8</td><td style=\"text-align: right;\">  64</td><td style=\"text-align: right;\">  16</td><td style=\"text-align: right;\">0.00594048</td><td style=\"text-align: right;\">     3</td><td style=\"text-align: right;\">        133.578 </td><td style=\"text-align: right;\">1.38654</td><td style=\"text-align: right;\">    0.5169</td></tr>\n",
        "</tbody>\n",
        "</table>\n",
        "  </div>\n",
@@ -354,10 +350,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [1,  2000] loss: 2.031\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [1,  4000] loss: 0.855\n"
+      "\u001b[2m\u001b[36m(func pid=2044)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=2044)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=2044)\u001b[0m [1,  2000] loss: 2.034\n"
      ]
     },
     {
@@ -370,9 +365,9 @@
        "<tr><th>Trial name             </th><th style=\"text-align: right;\">  accuracy</th><th style=\"text-align: right;\">   loss</th><th>should_checkpoint  </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>train_cifar_85549_00000</td><td style=\"text-align: right;\">    0.5236</td><td style=\"text-align: right;\">1.33847</td><td>True               </td></tr>\n",
-       "<tr><td>train_cifar_85549_00001</td><td style=\"text-align: right;\">    0.1012</td><td style=\"text-align: right;\">2.30289</td><td>True               </td></tr>\n",
-       "<tr><td>train_cifar_85549_00002</td><td style=\"text-align: right;\">    0.0991</td><td style=\"text-align: right;\">2.31742</td><td>True               </td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00000</td><td style=\"text-align: right;\">    0.4051</td><td style=\"text-align: right;\">1.60259</td><td>True               </td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00001</td><td style=\"text-align: right;\">    0.4041</td><td style=\"text-align: right;\">1.60811</td><td>True               </td></tr>\n",
+       "<tr><td>train_cifar_c8fdd_00002</td><td style=\"text-align: right;\">    0.5169</td><td style=\"text-align: right;\">1.38654</td><td>True               </td></tr>\n",
        "</tbody>\n",
        "</table>\n",
        "</div>\n",
@@ -401,36 +396,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [2,  2000] loss: 1.519\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [2,  4000] loss: 0.741\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [3,  2000] loss: 1.387\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [3,  4000] loss: 0.680\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [1,  2000] loss: 2.310\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m Files already downloaded and verified\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [1,  2000] loss: 2.328\n",
-      "\u001b[2m\u001b[36m(func pid=613)\u001b[0m [1,  4000] loss: 1.164\n"
+      "\u001b[2m\u001b[36m(func pid=2044)\u001b[0m [2,  2000] loss: 1.677\n",
+      "\u001b[2m\u001b[36m(func pid=2044)\u001b[0m [3,  2000] loss: 1.587\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [1,  2000] loss: 2.145\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [1,  4000] loss: 0.981\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [1,  6000] loss: 0.635\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [1,  8000] loss: 0.451\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [1, 10000] loss: 0.347\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [2,  2000] loss: 1.679\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [2,  4000] loss: 0.821\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [2,  6000] loss: 0.534\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [2,  8000] loss: 0.394\n",
+      "\u001b[2m\u001b[36m(func pid=24115)\u001b[0m [2, 10000] loss: 0.313\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m Files already downloaded and verified\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [1,  2000] loss: 1.977\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [1,  4000] loss: 0.826\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [2,  2000] loss: 1.518\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [2,  4000] loss: 0.744\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [3,  2000] loss: 1.414\n",
+      "\u001b[2m\u001b[36m(func pid=77348)\u001b[0m [3,  4000] loss: 0.703\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-02-09 21:25:57,532\tINFO tune.py:1148 -- Total run time: 125.94 seconds (125.86 seconds for the tuning loop).\n"
+      "2024-06-16 20:19:59,645\tINFO tune.py:1148 -- Total run time: 438.22 seconds (438.11 seconds for the tuning loop).\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best trial config: {'l1': 128, 'l2': 4, 'lr': 0.0023442259797773063, 'batch_size': 8}\n",
-      "Best trial final validation loss: 1.3384706589221955\n",
-      "Best trial final validation accuracy: 0.5236\n",
+      "Best trial config: {'l1': 64, 'l2': 16, 'lr': 0.005940475579325228, 'batch_size': 8}\n",
+      "Best trial final validation loss: 1.3865361887693406\n",
+      "Best trial final validation accuracy: 0.5169\n",
       "Files already downloaded and verified\n",
       "Files already downloaded and verified\n",
-      "Best trial test set accuracy: 0.5226\n"
+      "Best trial test set accuracy: 0.5088\n"
      ]
     }
    ],
@@ -485,13 +491,13 @@
     "\n",
     "if __name__ == \"__main__\":\n",
     "    # You can change the number of trials and GPUs here:\n",
-    "    main(num_samples=3, max_num_epochs=3, gpus_per_trial=0)"
+    "    main(num_samples=3, max_num_epochs=3, gpus_per_trial=2)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48d896ed-25ad-43eb-b164-99e6925c0307",
+   "id": "3afac7fa-f7e5-4d69-9db9-0c6ffe11f3c4",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Hey Vidushi,

I was testing the Ray Tune notebook with 2 GPUs for a customer and I ran into the attached error.

I did some research and tests and it seems like setting NCCL_SHM_DISABLE=1 solves the issue, but I have not done a more complete investigation. 

Reference:
[https://stackoverflow.com/questions/74003230/runtimeerror-nccl-error-2-unhandled-system-error](https://stackoverflow.com/questions/74003230/runtimeerror-nccl-error-2-unhandled-system-error)

"Use the NCCL_SHM_DISABLE environment variable to prevent nccl from trying to use this data pathway (see in the documentation [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-shm-disable)). This will force nccl to fall back to a potentially slower data pathway."

Workspace Specs Tested:

Version: 2.0.45-b81
AWS
CML CPU Workers | m5.4xlarge 
CML GPU Workers | g4dn.12xlarge 

Session Specs Tested:

Runtime:  docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-jupyterlab-python3.10-cuda:2024.05.1-b8
Res Profile: 4 CPU / 16 GB Mem / 2 GPU

Please have a look at this when you can and let me know your thoughts, in the meantime I have added the variable to the notebook.

Thanks,
Paul